### PR TITLE
Dropped lodash and got rid of annoying rework.properties warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,16 @@
 'use strict';
 var gutil = require('gulp-util');
 var through = require('through2');
-var _ = require('lodash');
 var rework = require('rework');
-var lastIsObject = _.compose(_.isPlainObject, _.last);
+
+function lastIsObject(args) {
+    var last = args[args.length -1];
+    if(typeof(last) !== 'object') { return false; }
+    if(Array.isArray(last)) { return false; }
+    if(last.prototype !== {}.prototype) { return false; }
+    if(last.constructor !== {}.constructor) { return false; }
+    return true;
+}
 
 module.exports = function () {
 	var args = [].slice.call(arguments);
@@ -34,5 +41,12 @@ module.exports = function () {
 	});
 };
 
-// mixin the rework built-in plugins
-_.assign(module.exports, rework);
+var reworkIgnores = ['properties'];
+
+for(var prop in rework) {
+    if(!~reworkIgnores.indexOf(prop)) {
+        if(rework.hasOwnProperty(prop) && typeof rework[prop] === 'function') {
+            module.exports[prop] = rework[prop].bind(rework);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "gulp-util": "~2.2.5",
     "through2": "~0.4.0",
-    "lodash": "~2.4.1",
     "rework": "~0.20.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I figured that lodash is a pretty large dependency and we don't really use it too much, so I implemented the same functionality and got rid of the need for lodash.

Additionally, I kept getting a warning for `rework.properties has been removed.`. This was happening because `_.assign` calls `rework.properties` which makes that error to fire. This blacklists properties.

Cheers!
