### PR TITLE
error return fileName

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = function () {
 			plugins.forEach(ret.use.bind(ret));
 			file.contents = new Buffer(ret.toString(options));
 		} catch (err) {
+			err.fileName = file.path;
 			this.emit('error', new gutil.PluginError('gulp-rework', err));
 		}
 


### PR DESCRIPTION
Hi,

A little addition to send an error with a `fileName` property. Exactly like `gulp-uglify` here :
 https://github.com/terinjokes/gulp-uglify/blob/master/index.js#L55

It's usefull if you want notice where the error is, example:

``` js
var r = rework(rework.mixin(mixins), vars(), shade());
r.on('error', function(err) {
  console.log('Rework error with file', err.fileName);
  r.end();
})
```
