### PR TITLE
Use filename from css.parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function () {
 			plugins.forEach(ret.use.bind(ret));
 			file.contents = new Buffer(ret.toString(options));
 		} catch (err) {
-			this.emit('error', new gutil.PluginError('gulp-rework', err, {fileName: file.path}));
+			this.emit('error', new gutil.PluginError('gulp-rework', err, {fileName: err.filename || file.path}));
 		}
 
 		this.push(file);


### PR DESCRIPTION
The file we're compiling might not be the same as the file that contains the error. i.e., if we're using the `rework-import` or `rework-npm` plugins.
