### PR TITLE
Add support for CSS source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,13 @@ const _ = require('lodash');
 const rework = require('rework');
 const PluginError = require('plugin-error');
 const Buffer = require('safe-buffer').Buffer;
+const applySourceMap = require('vinyl-sourcemaps-apply');
 
 const lastIsObject = _.flowRight(_.isPlainObject, _.last);
 
 module.exports = function () {
 	const args = [].slice.call(arguments);
-	const options = lastIsObject(args) ? args.pop() : {};
+	const options = Object.assign({}, lastIsObject(args) ? args.pop() : {});
 	const plugins = args;
 
 	return through.obj((file, enc, cb) => {
@@ -26,7 +27,25 @@ module.exports = function () {
 		try {
 			const ret = rework(file.contents.toString(), {source: file.path});
 			plugins.forEach(ret.use.bind(ret));
-			file.contents = Buffer.from(ret.toString(options));
+
+			if (file.sourceMap) {
+				options.sourcemap = true;
+				options.inputSourcemap = false;
+				options.sourcemapAsObject = true;
+			}
+			const result = ret.toString(options);
+			if (file.sourceMap) {
+				file.contents = Buffer.from(result.code);
+
+				result.map.file = file.relative;
+				result.map.sources = result.map.sources.map(() => {
+					return file.relative;
+				});
+
+				applySourceMap(file, result.map);
+			} else {
+				file.contents = Buffer.from(result);
+			}
 			cb(null, file);
 		} catch (err) {
 			cb(new PluginError('gulp-rework', err, {fileName: err.filename || file.path}));

--- a/index.js
+++ b/index.js
@@ -33,19 +33,17 @@ module.exports = function () {
 				options.inputSourcemap = false;
 				options.sourcemapAsObject = true;
 			}
+
 			const result = ret.toString(options);
 			if (file.sourceMap) {
 				file.contents = Buffer.from(result.code);
-
 				result.map.file = file.relative;
-				result.map.sources = result.map.sources.map(() => {
-					return file.relative;
-				});
-
+				result.map.sources = result.map.sources.map(() => file.relative);
 				applySourceMap(file, result.map);
 			} else {
 				file.contents = Buffer.from(result);
 			}
+
 			cb(null, file);
 		} catch (err) {
 			cb(new PluginError('gulp-rework', err, {fileName: err.filename || file.path}));

--- a/package.json
+++ b/package.json
@@ -36,11 +36,13 @@
 		"plugin-error": "^0.1.2",
 		"rework": "^1.0.0",
 		"safe-buffer": "^5.1.1",
-		"through2": "^2.0.0"
+		"through2": "^2.0.0",
+		"vinyl-sourcemaps-apply": "^0.2.1"
 	},
 	"devDependencies": {
 		"mocha": "*",
 		"rework-plugin-at2x": "^1.0.1",
+		"source-map": "^0.6.1",
 		"vinyl": "^2.1.0",
 		"xo": "*"
 	}

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const at2x = require('rework-plugin-at2x');
 const Vinyl = require('vinyl');
+const sourcemap = require('source-map');
 const rework = require('.');
 
 it('should preprocess CSS using Rework', cb => {
@@ -35,4 +36,73 @@ it('should support Source Map', cb => {
 	stream.end(new Vinyl({
 		contents: Buffer.from('.logo{background-image:url(\'component.png\') at-2x;width:289px;height:113px;}')
 	}));
+});
+
+function identityPlugin() {
+	return () => {};
+}
+
+it('should support gulp-sourcemap', cb => {
+	const map = new sourcemap.SourceMapGenerator({file: 'src/styles/logo.css'});
+	map.addMapping({
+		generated: {line: 1, column: 0},
+		source: 'src/styles/mixin.scss',
+		original: {line: 33, column: 2},
+		name: 'abc'
+	});
+
+	const file = new Vinyl({
+		path: '/Users/me/code/src/styles/logo.css',
+		base: '/Users/me/code',
+		contents: Buffer.from('.logo{width:289px;}')
+	});
+	file.sourceMap = map.toJSON();
+
+	const stream = rework(identityPlugin());
+
+	stream.on('data', data => {
+		try {
+			assert.equal(
+				data.contents.toString(),
+				'.logo {\n  width: 289px;\n}'
+			);
+
+			const map = new sourcemap.SourceMapConsumer(data.sourceMap);
+			assert.deepEqual(
+				map.originalPositionFor({line: 2, column: 2}),
+				{line: 33, column: 2, source: 'src/styles/mixin.scss', name: 'abc'});
+
+			cb();
+		} catch (err) {
+			cb(err);
+		}
+	});
+
+	stream.write(file);
+});
+
+it('should not override given options', cb => {
+	const map = new sourcemap.SourceMapGenerator({file: 'src/styles/logo.css'});
+	const file = new Vinyl({
+		path: 'src/styles/logo.css',
+		contents: Buffer.from('.logo{width:289px;}')
+	});
+	file.sourceMap = map.toJSON();
+	const options = {};
+
+	const stream = rework(identityPlugin(), options);
+
+	stream.on('data', () => {
+		try {
+			assert.deepEqual(
+				options, {}
+			);
+
+			cb();
+		} catch (err) {
+			cb(err);
+		}
+	});
+
+	stream.write(file);
 });


### PR DESCRIPTION
Add support for generating css sourcemaps using gulp-sourcemaps.

https://www.npmjs.com/package/gulp-sourcemaps
